### PR TITLE
Feature/append commit hash to log

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
     value: true
@@ -10,7 +10,7 @@ exports.default = function (_ref) {
     return {
         visitor: {
             CallExpression: function CallExpression(path, options) {
-                var loggers = options.opts.loggers || [{ pattern: 'console' }];
+                var loggers = options.opts.loggers || [{ pattern: "console" }];
                 if (isLogger(path, loggers)) {
                     var description = [];
                     var _iteratorNormalCompletion = true;
@@ -24,7 +24,7 @@ exports.default = function (_ref) {
                             if (description.length === 0) {
                                 var relativePath = void 0;
                                 var filePath = this.file.log.filename;
-                                if (filePath.charAt(0) !== '/') {
+                                if (filePath.charAt(0) !== "/") {
                                     relativePath = filePath;
                                 } else {
                                     var cwd = process.cwd();
@@ -33,7 +33,9 @@ exports.default = function (_ref) {
 
                                 var line = expression.loc.start.line;
                                 var column = expression.loc.start.column;
-                                description.push(relativePath + ':' + line + ':' + column + ':' + this.file.code.substring(expression.start, expression.end));
+                                var commit = commitHash ? ":commit " + commitHash : "";
+
+                                description.push(relativePath + ":" + line + ":" + column + ":" + this.file.code.substring(expression.start, expression.end) + commit);
                             } else {
                                 description.push(this.file.code.substring(expression.start, expression.end));
                             }
@@ -53,15 +55,25 @@ exports.default = function (_ref) {
                         }
                     }
 
-                    path.node.arguments.unshift(t.stringLiteral(description.join(',')));
+                    path.node.arguments.unshift(t.stringLiteral(description.join(",")));
                 }
             }
         }
     };
 };
 
-var _ = require('lodash');
+var _ = require("lodash");
+var exec = require("child_process").exec;
+var commitHash = "";
 
+exec("git rev-parse --short HEAD", function processExecution(error, result) {
+    if (error) {
+        console.info(error);
+        process.exit(0);
+    }
+
+    commitHash = process.env.NODE_ENV === "test" ? "000" : result;
+});
 
 function isLogger(path, loggers) {
     return _.some(loggers, function (logger) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "url": "git://github.com/furstenheim/babel-plugin-meaningful-logs.git"
   },
   "scripts": {
-    "test": "mocha  test/main.js",
+    "test": "NODE_ENV='test' mocha  test/main.js",
+    "test-watch": "NODE_ENV='test'npm run build && mocha --watch test/main.js",
     "build": "babel index.js -d dist",
     "build-test": "npm run build && npm test"
   },

--- a/test/expected/map.js
+++ b/test/expected/map.js
@@ -5,4 +5,4 @@ function square(n) {
 }
 var b = [1, 2, 3, 4];
 
-console.log("test/src/map.js:8:12:b.map(square)", b.map(square));
+console.log("test/src/map.js:8:12:b.map(square):commit 000", b.map(square));

--- a/test/expected/readLoggerFromOptions.js
+++ b/test/expected/readLoggerFromOptions.js
@@ -5,4 +5,4 @@ function square(n) {
 }
 var b = [1, 2, 3, 4];
 
-winston.log("test/src/readLoggerFromOptions.js:8:12:b.map(square)", b.map(square));
+winston.log("test/src/readLoggerFromOptions.js:8:12:b.map(square):commit 000", b.map(square));

--- a/test/expected/test1.js
+++ b/test/expected/test1.js
@@ -3,4 +3,4 @@ function square(n) {
 }
 n;
 
-console.log("test/src/test1.js:6:12:b * b", b * b);
+console.log("test/src/test1.js:6:12:b * b:commit 000", b * b);


### PR DESCRIPTION
Hey there, just had this idea and did a quick production-ready implementation that appends to every log the current commit hash (HEAD hash). Additionally added also some minor improvements:

- More consistent code style (make use of `let`, `const` instead of `var`)
- Add `test-watch` npm script for development convenience, it builds and tests at every file change within the watch mode of `mocha`